### PR TITLE
Updated parent POM to v2.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent> 
         <groupId>org.jenkins-ci.plugins</groupId> 
         <artifactId>plugin</artifactId> 
-        <version>1.480.3</version>
+        <version>2.33</version>
     </parent>
 
     <groupId>com.programmingresearch</groupId>
@@ -16,6 +16,7 @@
     <url>https://wiki.jenkins-ci.org/display/JENKINS/PRQA+Plugin</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jenkins.version>2.0</jenkins.version>
     </properties>
 
     <build>
@@ -84,6 +85,11 @@
             <groupId>net.praqma</groupId>
             <artifactId>praqmajutils</artifactId>
             <version>0.1.28</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/PRQARemoteReport.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/PRQARemoteReport.java
@@ -24,9 +24,9 @@
 package net.praqma.jenkins.plugin.prqa;
 
 import hudson.FilePath;
-import hudson.FilePath.FileCallable;
 import hudson.model.BuildListener;
 import hudson.remoting.VirtualChannel;
+import jenkins.MasterToSlaveFileCallable;
 import net.praqma.prqa.PRQAApplicationSettings;
 import net.praqma.prqa.PRQAContext;
 import net.praqma.prqa.PRQAReportSettings;
@@ -47,7 +47,7 @@ import java.util.Map;
  *
  * @author Praqma
  */
-public class PRQARemoteReport implements FileCallable<PRQAComplianceStatus>{
+public class PRQARemoteReport extends MasterToSlaveFileCallable<PRQAComplianceStatus> {
 
 	private static final long serialVersionUID = 1L;
 	

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/PRQARemoteToolCheck.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/PRQARemoteToolCheck.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import jenkins.MasterToSlaveFileCallable;
 import net.praqma.prqa.PRQAApplicationSettings;
 import net.praqma.prqa.ReportSettings;
 import net.praqma.prqa.exceptions.PrqaSetupException;
@@ -45,7 +46,7 @@ import org.apache.commons.lang.StringUtils;
 
 import com.google.common.base.Strings;
 
-public class PRQARemoteToolCheck implements FileCallable<String> {
+public class PRQARemoteToolCheck extends MasterToSlaveFileCallable<String> {
 
 	public final BuildListener listener;
 	public final boolean isUnix;

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/QAFrameworkRemoteReport.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/QAFrameworkRemoteReport.java
@@ -33,6 +33,7 @@ import java.io.PrintStream;
 import java.util.Collections;
 import java.util.Map;
 
+import jenkins.MasterToSlaveFileCallable;
 import net.praqma.prqa.PRQAApplicationSettings;
 import net.praqma.prqa.QaFrameworkVersion;
 import net.praqma.prqa.exceptions.PrqaException;
@@ -45,7 +46,7 @@ import org.apache.commons.lang.StringUtils;
 
 import static net.praqma.prqa.reports.ReportType.*;
 
-public class QAFrameworkRemoteReport implements FileCallable<PRQAComplianceStatus> {
+public class QAFrameworkRemoteReport extends MasterToSlaveFileCallable<PRQAComplianceStatus> {
 
     private static final long serialVersionUID = 1L;
     private QAFrameworkReport report;

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/QAFrameworkRemoteReportUpload.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/QAFrameworkRemoteReportUpload.java
@@ -34,6 +34,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 
+import jenkins.MasterToSlaveFileCallable;
 import net.praqma.prqa.PRQAApplicationSettings;
 import net.praqma.prqa.QaFrameworkVersion;
 import net.praqma.prqa.exceptions.PrqaException;
@@ -44,7 +45,7 @@ import net.prqma.prqa.qaframework.QaFrameworkReportSettings;
 
 import org.apache.commons.lang.StringUtils;
 
-public class QAFrameworkRemoteReportUpload implements FileCallable<Void>, Serializable {
+public class QAFrameworkRemoteReportUpload extends MasterToSlaveFileCallable<Void> implements Serializable {
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/globalconfig/QAVerifyServerConfiguration.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/globalconfig/QAVerifyServerConfiguration.java
@@ -5,6 +5,7 @@
 package net.praqma.jenkins.plugin.prqa.globalconfig;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import hudson.tools.ToolInstallation;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -120,21 +121,16 @@ public class QAVerifyServerConfiguration extends ToolInstallation implements Ser
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if (obj instanceof QAVerifyServerConfiguration) {
-			if (this == obj) {
-				return true;
-			}
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		QAVerifyServerConfiguration that = (QAVerifyServerConfiguration) o;
+		return Objects.equals(getConfigurationName(), that.getConfigurationName());
+	}
 
-			QAVerifyServerConfiguration qavsc = (QAVerifyServerConfiguration) obj;
-
-			return (qavsc.getConfigurationName() != null && getConfigurationName() != null)
-					&& qavsc.getConfigurationName().equals(
-							getConfigurationName());
-
-		} else {
-			return false;
-		}
+	@Override
+	public int hashCode() {
+		return Objects.hash(getConfigurationName());
 	}
 
 	public String getFullUrl() {

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/globalconfig/QAVerifyServerConfiguration.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/globalconfig/QAVerifyServerConfiguration.java
@@ -122,8 +122,12 @@ public class QAVerifyServerConfiguration extends ToolInstallation implements Ser
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
 		QAVerifyServerConfiguration that = (QAVerifyServerConfiguration) o;
 		return Objects.equals(getConfigurationName(), that.getConfigurationName());
 	}

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/graphs/ComplianceIndexGraphs.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/graphs/ComplianceIndexGraphs.java
@@ -3,10 +3,13 @@ package net.praqma.jenkins.plugin.prqa.graphs;
 import hudson.util.ChartUtil;
 import hudson.util.DataSetBuilder;
 import java.io.IOException;
+
+import hudson.util.Graph;
 import net.praqma.prqa.exceptions.PrqaException;
 import net.praqma.prqa.PRQAContext;
 import net.praqma.prqa.PRQAStatusCollection;
 import net.praqma.prqa.status.StatusCategory;
+import org.jfree.chart.JFreeChart;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -44,7 +47,13 @@ public class ComplianceIndexGraphs extends PRQAGraph {
             }
         }
         if(max != null && min != null) {
-            ChartUtil.generateGraph( req, rsp, createChart( dsb.build(), getTitle() , null, max.intValue(), min.intValue()), width, height );
+            final JFreeChart chart = createChart(dsb.build(), getTitle(), null, max.intValue(), min.intValue());
+
+            new Graph(-1,width,height) {
+                protected JFreeChart createGraph() {
+                    return chart;
+                }
+            }.doPng(req,rsp);
         }
     }
 }

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/graphs/PRQAGraph.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/graphs/PRQAGraph.java
@@ -1,17 +1,13 @@
 package net.praqma.jenkins.plugin.prqa.graphs;
 
-import hudson.util.*;
-
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import net.praqma.prqa.exceptions.PrqaException;
+import hudson.util.ChartUtil;
+import hudson.util.ColorPalette;
+import hudson.util.DataSetBuilder;
+import hudson.util.Graph;
+import hudson.util.ShiftedCategoryAxis;
 import net.praqma.prqa.PRQAContext;
 import net.praqma.prqa.PRQAStatusCollection;
+import net.praqma.prqa.exceptions.PrqaException;
 import net.praqma.prqa.status.StatusCategory;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
@@ -27,7 +23,16 @@ import org.jfree.ui.RectangleEdge;
 import org.jfree.ui.RectangleInsets;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
-import java.util.logging.*;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  *

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/graphs/PRQAGraph.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/graphs/PRQAGraph.java
@@ -1,9 +1,7 @@
 package net.praqma.jenkins.plugin.prqa.graphs;
 
-import hudson.util.ChartUtil;
-import hudson.util.ColorPalette;
-import hudson.util.DataSetBuilder;
-import hudson.util.ShiftedCategoryAxis;
+import hudson.util.*;
+
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.io.IOException;
@@ -102,7 +100,14 @@ public abstract class PRQAGraph implements Serializable {
             }
             log.fine("Iterating using category: "+category);
             if(max != null && min != null) {
-                ChartUtil.generateGraph( req, rsp, createChart( dsb.build(), getTitle() == null ? category.toString() : getTitle() , null, threshHoldMax != null ? threshHoldMax.intValue() : max.intValue(), min.intValue()), width, height );     
+
+                final JFreeChart chart = createChart(dsb.build(), getTitle() == null ? category.toString() : getTitle(), null, threshHoldMax != null ? threshHoldMax.intValue() : max.intValue(), min.intValue());
+
+                new Graph(-1,width,height) {
+                    protected JFreeChart createGraph() {
+                        return chart;
+                    }
+                }.doPng(req,rsp);
             }
         
         }

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQABuildAction.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQABuildAction.java
@@ -1,6 +1,7 @@
 package net.praqma.jenkins.plugin.prqa.notifier;
 import hudson.model.AbstractBuild;
 import hudson.model.Action;
+import hudson.model.Run;
 import hudson.tasks.Publisher;
 import hudson.util.ChartUtil;
 import hudson.util.DataSetBuilder;
@@ -156,7 +157,6 @@ public class PRQABuildAction implements Action {
             PRQAGraph graph =  notifier.getGraph(className);
             for(PRQABuildAction prqabuild = this; prqabuild != null; prqabuild = prqabuild.getPreviousAction()) {
                 if(prqabuild.getResult() != null) {
-                    PRQAReading stat = prqabuild.getResult();
                     for(StatusCategory cat : graph.getCategories()) {
                         Number threshold = prqabuild.getThreshold(cat);                                                       
                         if(threshold != null) {
@@ -203,7 +203,7 @@ public class PRQABuildAction implements Action {
             
             for(PRQABuildAction prqabuild = this; prqabuild != null; prqabuild = prqabuild.getPreviousAction()) {
                 if(prqabuild.getResult() != null) {
-                    label = new ChartUtil.NumberOnlyBuildLabel(prqabuild.build);
+                    label = new ChartUtil.NumberOnlyBuildLabel((Run<?, ?>) prqabuild.build);
                     PRQAReading stat = prqabuild.getResult();
                     for(StatusCategory cat : graph.getCategories()) {
                         Number res = null;

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQAFileProjectSource.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQAFileProjectSource.java
@@ -4,11 +4,13 @@ import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import jenkins.model.Jenkins;
 
-public class PRQAFileProjectSource implements Describable<PRQAFileProjectSource>, ExtensionPoint {
+public class PRQAFileProjectSource implements Describable<PRQAFileProjectSource>, ExtensionPoint, Serializable {
 
     @Override
     public Descriptor<PRQAFileProjectSource> getDescriptor() {

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQANotifier.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQANotifier.java
@@ -8,12 +8,17 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.util.ListBoxModel;
+import jenkins.model.ArtifactManager;
+import jenkins.model.Jenkins;
+import jenkins.util.BuildListenerAdapter;
 import net.praqma.jenkins.plugin.prqa.*;
 import net.praqma.jenkins.plugin.prqa.globalconfig.PRQAGlobalConfig;
 import net.praqma.jenkins.plugin.prqa.globalconfig.QAVerifyServerConfiguration;
 import net.praqma.jenkins.plugin.prqa.graphs.ComplianceIndexGraphs;
 import net.praqma.jenkins.plugin.prqa.graphs.MessagesGraph;
 import net.praqma.jenkins.plugin.prqa.graphs.PRQAGraph;
+import net.praqma.jenkins.plugin.prqa.notifier.slave.filesystem.CopyReportsToWorkspace;
+import net.praqma.jenkins.plugin.prqa.notifier.slave.filesystem.DeleteReportsFromWorkspace;
 import net.praqma.jenkins.plugin.prqa.setup.PRQAToolSuite;
 import net.praqma.jenkins.plugin.prqa.setup.QACToolSuite;
 import net.praqma.jenkins.plugin.prqa.setup.QAFrameworkInstallationConfiguration;
@@ -40,11 +45,11 @@ import net.prqma.prqa.qaframework.QaFrameworkReportSettings;
 import net.sf.json.JSONObject;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.ArrayUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -61,7 +66,7 @@ public class PRQANotifier extends Publisher implements Serializable {
     private static final long serialVersionUID = 1L;
     private static final Logger log = Logger.getLogger(PRQANotifier.class.getName());
     private static final String PROJECT_EXTENSION = "prj";
-    private PrintStream outStream;
+    private transient PrintStream outStream;
     private List<PRQAGraph> graphTypes;
     public final String settingProjectCompliance;
     public final String snapshotName;
@@ -104,15 +109,31 @@ public class PRQANotifier extends Publisher implements Serializable {
         return BuildStepMonitor.BUILD;
     }
 
-    private void copyResourcesToArtifactsDir(String pattern, AbstractBuild<?, ?> build) throws IOException,
+    private void copyResourcesToArtifactsDir(String pattern, AbstractBuild<?, ?> build, BuildListener listener) throws IOException,
             InterruptedException {
-        FilePath[] files = build.getWorkspace().list("**/" + pattern);
-        for (FilePath file : files) {
-            String artifactDir = build.getArtifactsDir().getPath();
-            FilePath targetDir = new FilePath(new File(artifactDir + "/" + file.getName()));
-            file.copyTo(targetDir);
-            outStream.println(Messages.PRQANotifier_SuccesFileCopy(file.getName()));
+        FilePath buildWorkspace = build.getWorkspace();
+
+        if (buildWorkspace == null) {
+            return;
         }
+
+        FilePath[] files = buildWorkspace.list("**/" + pattern);
+
+        Map<String, String> artifacts = new HashMap<>();
+
+        for (FilePath file : files) {
+            artifacts.put(file.getName(), file.getRemote().replaceAll(buildWorkspace.getRemote(), ""));
+        }
+
+        if (artifacts.isEmpty()) {
+            return;
+        }
+
+        BuildListenerAdapter adapter = new BuildListenerAdapter(listener);
+        ArtifactManager artifactManager = build.pickArtifactManager();
+        Launcher launcher = buildWorkspace.createLauncher(adapter);
+
+        artifactManager.archive(buildWorkspace, launcher, adapter, artifacts);
     }
 
     /**
@@ -187,16 +208,23 @@ public class PRQANotifier extends Publisher implements Serializable {
         }
     }
 
-    private void copyReportsToArtifactsDir(ReportSettings settings, AbstractBuild<?, ?> build) throws IOException,
+    private void copyReportsToArtifactsDir(ReportSettings settings, AbstractBuild<?, ?> build, BuildListener listener) throws IOException,
             InterruptedException {
+        FilePath buildWorkspace = build.getWorkspace();
+
+        if (buildWorkspace == null) {
+            throw new RuntimeException("Invalid workspace");
+        }
+
         if (settings instanceof PRQAReportSettings) {
             PRQAReportSettings prqaReportSettings = (PRQAReportSettings) settings;
             for (PRQAContext.QARReportType type : prqaReportSettings.chosenReportTypes) {
                 String pattern = "**/" + PRQAReport.getNamingTemplate(type, PRQAReport.XHTML_REPORT_EXTENSION);
-                FilePath[] files = build.getWorkspace().list(pattern);
+                FilePath[] files = buildWorkspace.list(pattern);
                 if (files.length >= 1) {
                     outStream.println(Messages.PRQANotifier_FoundReport(PRQAReport.getNamingTemplate(type,
                             PRQAReport.XHTML_REPORT_EXTENSION)));
+                    @SuppressWarnings("deprecation")
                     String artifactDir = build.getArtifactsDir().getPath();
 
                     FilePath targetDir = new FilePath(new File(artifactDir + "/"
@@ -212,12 +240,10 @@ public class PRQANotifier extends Publisher implements Serializable {
         } else if (settings instanceof QaFrameworkReportSettings) {
 
             QaFrameworkReportSettings qaFrameworkSettings = (QaFrameworkReportSettings) settings;
-            File workspace = new File(build.getWorkspace().getRemote());
 
-            File artifact = build.getArtifactsDir();
             try {
-                copyGeneratedReportsToJobWorkspace(workspace, qaFrameworkSettings.getQaProject());
-                copyReportsFromWorkspaceToArtifactsDir(artifact, workspace, build.getTimeInMillis());
+                copyGeneratedReportsToJobWorkspace(build, qaFrameworkSettings.getQaProject());
+                copyReportsFromWorkspaceToArtifactsDir(build, listener, build.getTimeInMillis());
             } catch (IOException ex) {
                 outStream.println("Manually add Build Artifacts to artifact or use plugin");
                 log.log(Level.SEVERE, "Failed copying build artifacts", ex.getCause());
@@ -225,30 +251,17 @@ public class PRQANotifier extends Publisher implements Serializable {
         }
     }
 
-    private void copyGeneratedReportsToJobWorkspace(File workspace, String qaProject) throws IOException {
-        if (workspace == null || qaProject == null) {
+    private void copyGeneratedReportsToJobWorkspace(AbstractBuild<?, ?> build, final String qaProject) throws IOException, InterruptedException {
+
+        FilePath buildWorkspace = build.getWorkspace();
+
+        if (buildWorkspace == null) {
             return;
         }
-        String reportsPath = "prqa/reports";
-        File qaFReports = new File(qaProject + "/" + reportsPath);
 
-        if (!qaFReports.isDirectory()) {
-            qaFReports = new File(workspace + "/" + qaProject + "/" + reportsPath);
-        }
+        CopyReportsToWorkspace cpy = new CopyReportsToWorkspace(qaProject);
 
-        if (qaFReports.isDirectory()) {
-            File[] files = qaFReports.listFiles();
-            if (ArrayUtils.isEmpty(files)) {
-                return;
-            }
-            if (workspace.isDirectory()) {
-                for (File reportFile : files) {
-                    if (containsReportName(reportFile.getName())) {
-                        FileUtils.copyFileToDirectory(reportFile, workspace);
-                    }
-                }
-            }
-        }
+        buildWorkspace.act(cpy);
     }
 
     private boolean containsReportName(String fileName) {
@@ -258,42 +271,53 @@ public class PRQANotifier extends Publisher implements Serializable {
                 fileName.contains(MDR.name());
     }
 
-    private void copyReportsFromWorkspaceToArtifactsDir(File artifact, File workspace, long elapsedTime)
-            throws IOException {
-        if (artifact == null) {
-            return;
-        }
-        if (!artifact.exists()) {
-            artifact.mkdirs();
-        }
-        FileUtils.cleanDirectory(artifact);
-        // COPY only last generated reports
-        File[] workspaceFiles = workspace.listFiles();
-        if (ArrayUtils.isEmpty(workspaceFiles)) {
-            return;
-        }
-        Arrays.sort(workspaceFiles, new Comparator<File>() {
+    private void copyReportsFromWorkspaceToArtifactsDir(AbstractBuild<?, ?> build, BuildListener listener, long elapsedTime)
+                throws IOException, InterruptedException {
 
+        // COPY only last generated reports
+        FilePath buildWorkspace = build.getWorkspace();
+        if (buildWorkspace == null) {
+            return;
+        }
+
+        List<FilePath> workspaceFiles = buildWorkspace.list();
+        if (workspaceFiles.isEmpty()) {
+            return;
+        }
+
+        Collections.sort(workspaceFiles, new Comparator<FilePath>() {
             @Override
-            public int compare(File o1, File o2) {
-                if (o1.lastModified() > o2.lastModified()) {
-                    return -1;
-                } else if (o1.lastModified() < o2.lastModified()) {
-                    return +1;
-                } else {
+            public int compare(FilePath o1, FilePath o2) {
+                try {
+                    return Long.compare(o2.lastModified(), o1.lastModified());
+                } catch (IOException | InterruptedException e) {
                     return 0;
                 }
             }
         });
 
-        for (File file : workspaceFiles) {
+        Map<String, String> artifacts = new HashMap<>();
+
+        for (FilePath file : workspaceFiles) {
             if (file.lastModified() < elapsedTime) {
                 break;
             }
+
             if (containsReportName(file.getName())) {
-                FileUtils.copyFileToDirectory(file, artifact);
+                artifacts.put(file.getName(), file.getName());
             }
         }
+
+        if (artifacts.isEmpty()) {
+            return;
+        }
+
+        BuildListenerAdapter adapter = new BuildListenerAdapter(listener);
+        Launcher launcher = buildWorkspace.createLauncher(adapter);
+        ArtifactManager artifactManager = build.pickArtifactManager();
+
+        artifactManager.archive(buildWorkspace, launcher, adapter, artifacts);
+
     }
 
     public List<PRQAGraph> getSupportedGraphs() {
@@ -320,34 +344,26 @@ public class PRQANotifier extends Publisher implements Serializable {
      */
     @Override
     public boolean prebuild(AbstractBuild<?, ?> build, BuildListener listener) {
-        try {
-            List<FilePath> files = build.getWorkspace().list(new ReportFileFilter());
-            int numberOfReportFiles = build.getWorkspace().list(new ReportFileFilter()).size();
-            if (numberOfReportFiles > 0) {
-                listener.getLogger().println(
-                        String.format("Found %s report fragments, cleaning up", numberOfReportFiles));
-            }
+        FilePath workspace = build.getWorkspace();
 
-            int deleteCounter = 0;
-            for (FilePath f : files) {
-                f.delete();
-                deleteCounter++;
-            }
-
-            if (deleteCounter > 0) {
-                listener.getLogger().println(String.format("Successfully deleted %s report fragments", deleteCounter));
-            }
-
-        } catch (IOException ex) {
-            listener.getLogger().println("Failed to clean up stale report files");
-            log.log(Level.SEVERE, "Cleanup crew missing!", ex);
-
-        } catch (InterruptedException ex) {
-            listener.getLogger().println("Failed to clean up stale report files");
-            log.log(Level.SEVERE, "Cleanup crew missing!", ex);
+        if (workspace == null) {
+            listener.getLogger().println("Invalid workspace. Cannot continue.");
+            return false;
         }
 
-        return true;
+        DeleteReportsFromWorkspace deleter = new DeleteReportsFromWorkspace();
+
+        try {
+            Boolean act = workspace.act(deleter);
+            if (!act) {
+                listener.getLogger().println("Failed to cleanup workspace reports.");
+            }
+            return act;
+        } catch (IOException | InterruptedException e) {
+            listener.getLogger().println("Failed to cleanup workspace reports.");
+            return false;
+        }
+
     }
 
     // TODO: Refactor this method is way too long
@@ -355,12 +371,19 @@ public class PRQANotifier extends Publisher implements Serializable {
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
 
-        Result buildResult = build.getResult();
-        if (buildResult.isWorseOrEqualTo(Result.FAILURE) && runWhenSuccess) {
-            build.setResult(Result.FAILURE);
-            return false;
-        }
         outStream = listener.getLogger();
+
+        Result buildResult = build.getResult();
+
+        if (buildResult == null) {
+            log.warning("Build result is unavailable at this point");
+        } else {
+            if (buildResult.isWorseOrEqualTo(Result.FAILURE) && runWhenSuccess) {
+                build.setResult(Result.FAILURE);
+                return false;
+            }
+        }
+
         if (sourceQAFramework != null && sourceQAFramework instanceof QAFrameworkPostBuildActionSetup) {
 
             return performQaFrameworkBuild(build, launcher, listener);
@@ -373,7 +396,13 @@ public class PRQANotifier extends Publisher implements Serializable {
         return true;
     }
 
-    private boolean performQaToolBuild(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+    private boolean performQaToolBuild(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws IOException {
+
+        FilePath workspace = build.getWorkspace();
+
+        if (workspace == null) {
+            throw new IOException("Invalid workspace. Cannot continue.");
+        }
 
         PRQAReportPRQAToolSource prqaReportPRQAToolSource = (PRQAReportPRQAToolSource) sourceQAFramework;
 
@@ -392,11 +421,9 @@ public class PRQANotifier extends Publisher implements Serializable {
 
         PRQAApplicationSettings appSettings = null;
         if (suite != null) {
-            if (suite instanceof QACToolSuite) {
-                QACToolSuite cSuite = (QACToolSuite) suite;
-                appSettings = new PRQAApplicationSettings(cSuite.qarHome, cSuite.qavHome, cSuite.qawHome,
-                        cSuite.getHome());
-            }
+            QACToolSuite cSuite = (QACToolSuite) suite;
+            appSettings = new PRQAApplicationSettings(cSuite.qarHome, cSuite.qavHome, cSuite.qawHome,
+                    cSuite.getHome());
         }
 
         PRQAReportSettings settings = null;
@@ -405,7 +432,7 @@ public class PRQANotifier extends Publisher implements Serializable {
         if (prqaReportPRQAToolSource.fileProjectSource != null
                 && prqaReportPRQAToolSource.fileProjectSource instanceof PRQAReportProjectFileSource) {
             PRQAReportProjectFileSource pSource = (PRQAReportProjectFileSource) prqaReportPRQAToolSource.fileProjectSource;
-            String projectFilePath = selectPrjFilePath(build.getWorkspace().getRemote(), pSource.projectFile);
+            String projectFilePath = selectPrjFilePath(workspace.getRemote(), pSource.projectFile);
             if (projectFilePath == null) {
                 outStream.println(String.format(
                         "File %s not found. Please provide a valid path to the project file", pSource.projectFile));
@@ -466,9 +493,9 @@ public class PRQANotifier extends Publisher implements Serializable {
 
         HashMap<String, String> environment = null;
         if (suite != null) {
-            environment = suite.createEnvironmentVariables(build.getWorkspace().getRemote());
+            environment = suite.createEnvironmentVariables(workspace.getRemote());
         }
-        outStream.println("Workspace : " + build.getWorkspace().getRemote());
+        outStream.println("Workspace : " + workspace.getRemote());
         boolean success = true;
         PRQAComplianceStatus currentBuild = null;
 
@@ -483,7 +510,7 @@ public class PRQANotifier extends Publisher implements Serializable {
             Collection<QAVerifyServerSettings> qavSettings = createServerSettings(prqaReportPRQAToolSource);
 
             PRQAReport report = new PRQAReport(settings, qavSettings, uploadSettings, appSettings, environment);
-            currentBuild = build.getWorkspace().act(new PRQARemoteReport(report, listener, launcher.isUnix()));
+            currentBuild = workspace.act(new PRQARemoteReport(report, listener, launcher.isUnix()));
             currentBuild.setMessagesWithinThreshold(currentBuild.getMessageCount(threshholdlevel));
         } catch (IOException ex) {
             success = treatIOException(ex);
@@ -500,10 +527,10 @@ public class PRQANotifier extends Publisher implements Serializable {
         } finally {
             try {
                 if (success) {
-                    copyReportsToArtifactsDir(settings, build);
+                    copyReportsToArtifactsDir(settings, build, listener);
                 }
                 if (prqaReportPRQAToolSource.publishToQAV && success) {
-                    copyResourcesToArtifactsDir("*.log", build);
+                    copyResourcesToArtifactsDir("*.log", build, listener);
                 }
             } catch (Exception ex) {
                 outStream.println("Auto Copy of Build Artifacts to artifact dir on Master Failed");
@@ -549,7 +576,7 @@ public class PRQANotifier extends Publisher implements Serializable {
         if (!buildStatus) {
             build.setResult(Result.UNSTABLE);
         }
-        build.getActions().add(action);
+        build.addAction(action);
         return true;
     }
 
@@ -561,7 +588,7 @@ public class PRQANotifier extends Publisher implements Serializable {
             servers.add(createServerSetting(server));
         }
 
-        return null;
+        return servers;
     }
 
     private QAVerifyServerSettings createServerSetting(String chosenServer) {
@@ -622,7 +649,7 @@ public class PRQANotifier extends Publisher implements Serializable {
         do {
             iterate = iterate.getPreviousNotFailedBuild();
             if (iterate != null && iterate.getAction(PRQABuildAction.class) != null
-                    && iterate.getResult().equals(expectedResult)) {
+                    && Objects.equals(iterate.getResult(), expectedResult)) {
                 Tuple<PRQAReading, AbstractBuild<?, ?>> result = new Tuple<PRQAReading, AbstractBuild<?, ?>>();
                 result.setSecond(iterate);
                 result.setFirst(iterate.getAction(PRQABuildAction.class).getResult());
@@ -673,7 +700,12 @@ public class PRQANotifier extends Publisher implements Serializable {
         }
 
         @Override
-        public Publisher newInstance(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
+        public Publisher newInstance(StaplerRequest req, @Nonnull JSONObject formData) throws Descriptor.FormException {
+
+            if (req == null) {
+                throw new FormException(new Exception("Bad request"), "Bad request");
+            }
+
             final String SOURCE_QA_FRAMEWORK = "sourceQAFramework";
             final String CODE_REVIEW_REPORT = "generateCrr";
             final String SUPPRESSION_REPORT = "generateSup";
@@ -713,13 +745,26 @@ public class PRQANotifier extends Publisher implements Serializable {
         }
 
         public List<QACToolSuite> getQacTools() {
-            QACToolSuite[] prqaInstallations = Hudson.getInstance()
+            Jenkins jenkins = Jenkins.getInstance();
+
+            if (jenkins == null) {
+                throw new RuntimeException("Unable to get Jenkins instance");
+            }
+
+            QACToolSuite[] prqaInstallations = jenkins
                     .getDescriptorByType(QACToolSuite.DescriptorImpl.class).getInstallations();
             return Arrays.asList(prqaInstallations);
         }
 
         public List<QAFrameworkInstallationConfiguration> getQaFrameworkTools() {
-            QAFrameworkInstallationConfiguration[] prqaInstallations = Hudson.getInstance()
+
+            Jenkins jenkins = Jenkins.getInstance();
+
+            if (jenkins == null) {
+                throw new RuntimeException("Unable to get Jenkins instance");
+            }
+
+            QAFrameworkInstallationConfiguration[] prqaInstallations = jenkins
                     .getDescriptorByType(QAFrameworkInstallationConfiguration.DescriptorImpl.class).getInstallations();
             return Arrays.asList(prqaInstallations);
         }
@@ -731,37 +776,46 @@ public class PRQANotifier extends Publisher implements Serializable {
 
     private boolean performQaFrameworkBuild(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
 
+        FilePath workspace = build.getWorkspace();
+
+        if (workspace == null) {
+            throw new IOException("Invalid workspace. Cannot continue.");
+        }
+
+        Computer currentComputer = Computer.currentComputer();
+
+        if (currentComputer == null) {
+            throw new IOException("Invalid machine. Cannot continue.");
+        }
+
+        Node node = currentComputer.getNode();
+        if (node == null) {
+            throw new IOException("Invalid machine. Cannot continue.");
+        }
+
         QAFrameworkPostBuildActionSetup qaFrameworkPostBuildActionSetup = (QAFrameworkPostBuildActionSetup) sourceQAFramework;
         QAFrameworkInstallationConfiguration qaFrameworkInstallationConfiguration = QAFrameworkInstallationConfiguration
                 .getInstallationByName(qaFrameworkPostBuildActionSetup.qaInstallation);
 
+        if (qaFrameworkInstallationConfiguration == null) {
+            String msg = String.format("The job uses a product configuration (%s) that no longer exists, please reconfigure.", "");
+            outStream.println(msg);
+            log.log(Level.WARNING, "PrqaException", msg);
+            return false;
+        }
 
-        qaFrameworkInstallationConfiguration = qaFrameworkInstallationConfiguration.forNode(Computer.currentComputer().getNode(), listener);
+        qaFrameworkInstallationConfiguration = qaFrameworkInstallationConfiguration.forNode(node, listener);
 
         outStream.println(VersionInfo.getPluginVersion());
 
-        PRQAToolSuite suite = null;
-        if (qaFrameworkInstallationConfiguration != null) {
-            suite = qaFrameworkInstallationConfiguration;
-        } else {
-            try {
-                throw new PrqaSetupException(String.format(
-                        "The job uses a product configuration (%s) that no longer exists, please reconfigure.", ""));
-            } catch (PrqaSetupException pex) {
-                outStream.println(pex.getMessage());
-                log.log(Level.WARNING, "PrqaException", pex.getCause());
-                return false;
-            }
-        }
+        PRQAToolSuite suite = qaFrameworkInstallationConfiguration;
 
         outStream.println(Messages.PRQANotifier_ReportGenerateText());
-        outStream.println("Workspace : " + build.getWorkspace().getRemote());
+        outStream.println("Workspace : " + workspace.getRemote());
 
-        HashMap<String, String> environmentVariables = null;
+        HashMap<String, String> environmentVariables;
 
-        if (suite != null) {
-            environmentVariables = suite.createEnvironmentVariables(build.getWorkspace().getRemote());
-        }
+        environmentVariables = suite.createEnvironmentVariables(workspace.getRemote());
 
         PRQAApplicationSettings appSettings = new PRQAApplicationSettings(
                 qaFrameworkInstallationConfiguration.getHome());
@@ -807,7 +861,7 @@ public class PRQANotifier extends Publisher implements Serializable {
                 remoteReport = remoteReports.iterator().next();
             }
 
-            currentBuild = performBuild(build, remoteToolCheck, remoteReport, qaReportSettings);
+            currentBuild = performBuild(build, remoteToolCheck, remoteReport, qaReportSettings, listener);
         } catch (PrqaException ex) {
             log.log(Level.WARNING, "PrqaException", ex.getMessage());
             return false;
@@ -839,48 +893,53 @@ public class PRQANotifier extends Publisher implements Serializable {
 
         Result buildResult = build.getResult();
 
-        if (!res) {
-            if (!buildResult.isWorseOrEqualTo(Result.FAILURE)) {
-                build.setResult(Result.UNSTABLE);
-            }
-            if (qaReportSettings.isLoginToQAV()
-                    && qaReportSettings.isPublishToQAV()
-                    && !qaReportSettings.isQaUploadWhenStable()
-                    && !buildResult.isWorseOrEqualTo(Result.FAILURE)) {
-                try {
-                    outStream.println("UPLOAD WARNING: Build is Unstable but upload will continue...");
-                    for (QAFrameworkRemoteReportUpload remoteReportUpload : remoteReportUploads ) {
-                        performUpload(build, appSettings, remoteToolCheck, remoteReportUpload);
-                    }
-                } catch (PrqaException ex) {
-                    log.log(Level.WARNING, "PrqaException", ex.getMessage());
-                    return false;
+        if (buildResult != null) {
+            if (!res) {
+                if (!buildResult.isWorseOrEqualTo(Result.FAILURE)) {
+                    build.setResult(Result.UNSTABLE);
                 }
-            } else if (qaReportSettings.isLoginToQAV()
-                    && qaReportSettings.isPublishToQAV()
-                    && (qaReportSettings.isQaUploadWhenStable()
-                    || buildResult.isWorseOrEqualTo(Result.FAILURE))) {
-                outStream.println("UPLOAD WARNING: QAV Upload cant be perform because build is Unstable");
-                log.warning("UPLOAD WARNING - QAV Upload cant be perform because build is Unstable");
-            }
+                if (qaReportSettings.isLoginToQAV()
+                        && qaReportSettings.isPublishToQAV()
+                        && !qaReportSettings.isQaUploadWhenStable()
+                        && !buildResult.isWorseOrEqualTo(Result.FAILURE)) {
+                    try {
+                        outStream.println("UPLOAD WARNING: Build is Unstable but upload will continue...");
+                        for (QAFrameworkRemoteReportUpload remoteReportUpload : remoteReportUploads) {
+                            performUpload(build, appSettings, remoteToolCheck, remoteReportUpload);
+                        }
+                    } catch (PrqaException ex) {
+                        log.log(Level.WARNING, "PrqaException", ex.getMessage());
+                        return false;
+                    }
+                } else if (qaReportSettings.isLoginToQAV()
+                        && qaReportSettings.isPublishToQAV()
+                        && (qaReportSettings.isQaUploadWhenStable()
+                        || buildResult.isWorseOrEqualTo(Result.FAILURE))) {
+                    outStream.println("UPLOAD WARNING: QAV Upload cant be perform because build is Unstable");
+                    log.warning("UPLOAD WARNING - QAV Upload cant be perform because build is Unstable");
+                }
 
-        } else if (qaReportSettings.isLoginToQAV() && qaReportSettings.isPublishToQAV()) {
-            if (buildResult.isWorseOrEqualTo(Result.FAILURE)
-                    && qaReportSettings.isQaUploadWhenStable()) {
-                outStream.println("UPLOAD WARNING: QAV Upload cant be perform because build is Unstable");
-                log.warning("UPLOAD WARNING - QAV Upload cant be perform because build is Unstable");
-            } else {
-                try {
-                    outStream.println("UPLOAD INFO: QAV Upload...");
-                    for (QAFrameworkRemoteReportUpload remoteReportUpload : remoteReportUploads ) {
-                        performUpload(build, appSettings, remoteToolCheck, remoteReportUpload);
+            } else if (qaReportSettings.isLoginToQAV() && qaReportSettings.isPublishToQAV()) {
+                if (buildResult.isWorseOrEqualTo(Result.FAILURE)
+                        && qaReportSettings.isQaUploadWhenStable()) {
+                    outStream.println("UPLOAD WARNING: QAV Upload cant be perform because build is Unstable");
+                    log.warning("UPLOAD WARNING - QAV Upload cant be perform because build is Unstable");
+                } else {
+                    try {
+                        outStream.println("UPLOAD INFO: QAV Upload...");
+                        for (QAFrameworkRemoteReportUpload remoteReportUpload : remoteReportUploads) {
+                            performUpload(build, appSettings, remoteToolCheck, remoteReportUpload);
+                        }
+                    } catch (PrqaException ex) {
+                        log.log(Level.WARNING, "PrqaException", ex.getMessage());
+                        return false;
                     }
-                } catch (PrqaException ex) {
-                    log.log(Level.WARNING, "PrqaException", ex.getMessage());
-                    return false;
                 }
             }
+        } else {
+            return false;
         }
+
         outStream.println("\n----------------------BUILD Results-----------------------\n");
         if (previousBuildResultTuple != null) {
             outStream.println(Messages.PRQANotifier_PreviousResultBuildNumber(previousBuildResultTuple.getSecond().number));
@@ -892,7 +951,7 @@ public class PRQANotifier extends Publisher implements Serializable {
         outStream.println(Messages.PRQANotifier_ScannedValues());
         outStream.println(currentBuild);
 
-        build.getActions().add(action);
+        build.addAction(action);
         return true;
     }
 
@@ -934,24 +993,33 @@ public class PRQANotifier extends Publisher implements Serializable {
 
         QAVerifyServerConfiguration qaVerifyServerConfiguration = PRQAGlobalConfig.get().getConfigurationByName(
                 configurationByName);
+
         if (qaVerifyServerConfiguration != null) {
             return new QAVerifyServerSettings(qaVerifyServerConfiguration.getHostName(),
-                    qaVerifyServerConfiguration.getViewerPortNumber(), qaVerifyServerConfiguration.getProtocol(),
-                    qaVerifyServerConfiguration.getPassword(), qaVerifyServerConfiguration.getUserName());
+                    qaVerifyServerConfiguration.getViewerPortNumber(),
+                    qaVerifyServerConfiguration.getProtocol(),
+                    qaVerifyServerConfiguration.getPassword(),
+                    qaVerifyServerConfiguration.getUserName());
         }
+
         return new QAVerifyServerSettings();
 
     }
 
     private PRQAComplianceStatus performBuild(AbstractBuild<?, ?> build,
                                               PRQARemoteToolCheck remoteToolCheck, QAFrameworkRemoteReport remoteReport,
-                                              QaFrameworkReportSettings qaReportSettings) throws PrqaException {
+                                              QaFrameworkReportSettings qaReportSettings, BuildListener listener) throws PrqaException, IOException {
 
         boolean success = true;
-        PRQAComplianceStatus currentBuild = null;
+        PRQAComplianceStatus currentBuild;
+        FilePath workspace = build.getWorkspace();
+
+        if (workspace == null) {
+            throw new IOException("Invalid workspace. Cannot continue.");
+        }
 
         try {
-            QaFrameworkVersion qaFrameworkVersion = new QaFrameworkVersion(build.getWorkspace().act(remoteToolCheck));
+            QaFrameworkVersion qaFrameworkVersion = new QaFrameworkVersion(workspace.act(remoteToolCheck));
             success = isQafVersionSupported(qaFrameworkVersion);
             if (!success) {
                 build.setResult(Result.FAILURE);
@@ -959,7 +1027,7 @@ public class PRQANotifier extends Publisher implements Serializable {
             }
 
             remoteReport.setQaFrameworkVersion(qaFrameworkVersion);
-            currentBuild = build.getWorkspace().act(remoteReport);
+            currentBuild = workspace.act(remoteReport);
             currentBuild.setMessagesWithinThresholdForEachMessageGroup(threshholdlevel);
         } catch (IOException ex) {
             success = false;
@@ -977,26 +1045,32 @@ public class PRQANotifier extends Publisher implements Serializable {
             throw new PrqaException("IO exception. Please retry.");
         } finally {
             if (success) {
-                copyArtifacts(build, qaReportSettings);
+                copyArtifacts(build, qaReportSettings, listener);
             }
         }
         return currentBuild;
     }
 
     private void performUpload(AbstractBuild<?, ?> build, PRQAApplicationSettings appSettings,
-                                               PRQARemoteToolCheck remoteToolCheck, QAFrameworkRemoteReportUpload remoteReportUpload) throws PrqaException {
+                                               PRQARemoteToolCheck remoteToolCheck, QAFrameworkRemoteReportUpload remoteReportUpload) throws PrqaException, IOException {
+
+        FilePath workspace = build.getWorkspace();
+
+        if (workspace == null) {
+            throw new IOException("Invalid workspace. Cannot continue.");
+        }
 
         boolean success;
 
         try {
-            QaFrameworkVersion qaFrameworkVersion = new QaFrameworkVersion(build.getWorkspace().act(remoteToolCheck));
+            QaFrameworkVersion qaFrameworkVersion = new QaFrameworkVersion(workspace.act(remoteToolCheck));
             success = isQafVersionSupported(qaFrameworkVersion);
             if (!success) {
                 build.setResult(Result.FAILURE);
                 throw new PrqaException("Build failure. Please upgrade to a newer version of PRQA Framework");
             }
             remoteReportUpload.setQaFrameworkVersion(qaFrameworkVersion);
-            build.getWorkspace().act(remoteReportUpload);
+            workspace.act(remoteReportUpload);
         } catch (IOException ex) {
             outStream.println(ex.getMessage());
             build.setResult(Result.FAILURE);
@@ -1013,10 +1087,9 @@ public class PRQANotifier extends Publisher implements Serializable {
     private boolean isQafVersionSupported(QaFrameworkVersion qaFrameworkVersion) {
         String shortVersion = qaFrameworkVersion.getVersionShortFormat();
         String qafVersion = shortVersion.substring(shortVersion.lastIndexOf(" ") + 1);
-        if (qaFrameworkVersion == null) {
-            return false;
-        }
+
         outStream.println("PRQA Source Code Analysis Framework " + qafVersion);
+
         if (!qaFrameworkVersion.isQAFVersionSupported()) {
             outStream.println(String.format(
                     "Your QA·CLI version is %s.In order to use our product install a newer version of PRQA·Framework!",
@@ -1030,12 +1103,12 @@ public class PRQANotifier extends Publisher implements Serializable {
      * TODO - in Master Salve Setup copy artifacts method do not work and throw exception.
      * This method need to be expanded or suggest user to use Copy Artifact Plugin.
      */
-    private void copyArtifacts(AbstractBuild<?, ?> build, QaFrameworkReportSettings qaReportSettings) {
+    private void copyArtifacts(AbstractBuild<?, ?> build, QaFrameworkReportSettings qaReportSettings, BuildListener listener) {
 
         try {
-            copyReportsToArtifactsDir(qaReportSettings, build);
+            copyReportsToArtifactsDir(qaReportSettings, build, listener);
             if (qaReportSettings.isPublishToQAV() && qaReportSettings.isLoginToQAV()) {
-                copyResourcesToArtifactsDir("*.log", build);
+                copyResourcesToArtifactsDir("*.log", build, listener);
             }
         } catch (Exception ex) {
             outStream.println("Auto Copy of Build Artifacts to artifact dir on Master Failed");

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQANotifier.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQANotifier.java
@@ -231,7 +231,7 @@ public class PRQANotifier extends Publisher implements Serializable {
                             + PRQAReport.getNamingTemplate(type, PRQAReport.XHTML_REPORT_EXTENSION)));
                     outStream.println(Messages.PRQANotifier_CopyToTarget(targetDir.getName()));
 
-                    build.getWorkspace().list(
+                    buildWorkspace.list(
                             "**/" + PRQAReport.getNamingTemplate(type, PRQAReport.XHTML_REPORT_EXTENSION))[0]
                             .copyTo(targetDir);
                     outStream.println(Messages.PRQANotifier_SuccesCopyReport());

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQANotifier.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQANotifier.java
@@ -45,6 +45,7 @@ import net.prqma.prqa.qaframework.QaFrameworkReportSettings;
 import net.sf.json.JSONObject;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
@@ -122,7 +123,7 @@ public class PRQANotifier extends Publisher implements Serializable {
         Map<String, String> artifacts = new HashMap<>();
 
         for (FilePath file : files) {
-            artifacts.put(file.getName(), file.getRemote().replaceAll(buildWorkspace.getRemote(), ""));
+            artifacts.put(file.getName(), StringUtils.replace(file.getRemote(), buildWorkspace.getRemote(), ""));
         }
 
         if (artifacts.isEmpty()) {

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQAProjectAction.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQAProjectAction.java
@@ -1,5 +1,6 @@
 package net.praqma.jenkins.plugin.prqa.notifier;
 
+import com.google.common.collect.Iterables;
 import hudson.model.ProminentProjectAction;
 import hudson.model.AbstractProject;
 import hudson.model.Actionable;
@@ -11,6 +12,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
+import hudson.util.Iterators;
+import hudson.util.RunList;
 import net.praqma.jenkins.plugin.prqa.globalconfig.PRQAGlobalConfig;
 import net.praqma.jenkins.plugin.prqa.globalconfig.QAVerifyServerConfiguration;
 
@@ -63,7 +66,8 @@ public class PRQAProjectAction extends Actionable implements ProminentProjectAct
 	 * @return true when there are more than 2 or more builds available.
 	 */
 	public boolean isDrawGraphs() {
-		return project.getBuilds().size() >= 2;
+		RunList<?> builds = project.getBuilds();
+		return Iterables.size(builds) >= 2;
 	}
 
 	/**

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQAProjectAction.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQAProjectAction.java
@@ -1,24 +1,21 @@
 package net.praqma.jenkins.plugin.prqa.notifier;
 
 import com.google.common.collect.Iterables;
-import hudson.model.ProminentProjectAction;
 import hudson.model.AbstractProject;
 import hudson.model.Actionable;
 import hudson.model.Descriptor;
+import hudson.model.ProminentProjectAction;
 import hudson.tasks.Publisher;
 import hudson.util.DescribableList;
+import hudson.util.RunList;
+import net.praqma.jenkins.plugin.prqa.globalconfig.PRQAGlobalConfig;
+import net.praqma.jenkins.plugin.prqa.globalconfig.QAVerifyServerConfiguration;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
-
-import hudson.util.Iterators;
-import hudson.util.RunList;
-import net.praqma.jenkins.plugin.prqa.globalconfig.PRQAGlobalConfig;
-import net.praqma.jenkins.plugin.prqa.globalconfig.QAVerifyServerConfiguration;
-
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * 

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQAReportPRQAToolSource.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PRQAReportPRQAToolSource.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 
+import jenkins.model.Jenkins;
 import net.praqma.jenkins.plugin.prqa.globalconfig.PRQAGlobalConfig;
 import net.praqma.jenkins.plugin.prqa.globalconfig.QAVerifyServerConfiguration;
 import net.praqma.jenkins.plugin.prqa.setup.QACToolSuite;
@@ -232,7 +233,13 @@ public class PRQAReportPRQAToolSource extends PostBuildActionSetup {
 		}
 
 		public List<QACToolSuite> getQAFrameworkTools() {
-			QACToolSuite[] prqaInstallations = Hudson.getInstance().getDescriptorByType(QACToolSuite.DescriptorImpl.class).getInstallations();
+			Jenkins instance = Jenkins.getInstance();
+
+			if (instance == null) {
+				throw new RuntimeException("Unable to aquire Jenkins instance");
+			}
+
+			QACToolSuite[] prqaInstallations = instance.getDescriptorByType(QACToolSuite.DescriptorImpl.class).getInstallations();
 			return Arrays.asList(prqaInstallations);
 		}
 

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PostBuildActionSetup.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/PostBuildActionSetup.java
@@ -27,6 +27,8 @@ import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import jenkins.model.Jenkins;
@@ -35,7 +37,7 @@ import jenkins.model.Jenkins;
  *
  * @author Praqma
  */
-public class PostBuildActionSetup implements Describable<PostBuildActionSetup>, ExtensionPoint {
+public class PostBuildActionSetup implements Describable<PostBuildActionSetup>, ExtensionPoint, Serializable {
 
     @Override
     public Descriptor<PostBuildActionSetup> getDescriptor() {

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/QAFrameworkPostBuildActionSetup.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/QAFrameworkPostBuildActionSetup.java
@@ -31,6 +31,7 @@ import hudson.util.ListBoxModel;
 import java.util.Arrays;
 import java.util.List;
 
+import jenkins.model.Jenkins;
 import net.praqma.jenkins.plugin.prqa.globalconfig.PRQAGlobalConfig;
 import net.praqma.jenkins.plugin.prqa.globalconfig.QAVerifyServerConfiguration;
 import net.praqma.jenkins.plugin.prqa.setup.QAFrameworkInstallationConfiguration;
@@ -269,8 +270,6 @@ public class QAFrameworkPostBuildActionSetup extends PostBuildActionSetup {
     @Extension
     public final static class DescriptorImpl extends PRQAReportSourceDescriptor<QAFrameworkPostBuildActionSetup> {
 
-        public boolean enabled = false;
-
         @Override
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
             save();
@@ -353,7 +352,13 @@ public class QAFrameworkPostBuildActionSetup extends PostBuildActionSetup {
         }
 
         public List<QAFrameworkInstallationConfiguration> getQAFrameworkTools() {
-            QAFrameworkInstallationConfiguration[] prqaInstallations = Hudson.getInstance()
+            Jenkins jenkins = Jenkins.getInstance();
+
+            if (jenkins == null) {
+                throw new RuntimeException("Unable to aquire Jenkins instance");
+            }
+
+            QAFrameworkInstallationConfiguration[] prqaInstallations = jenkins
                     .getDescriptorByType(QAFrameworkInstallationConfiguration.DescriptorImpl.class).getInstallations();
             return Arrays.asList(prqaInstallations);
         }

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/slave/filesystem/CopyReportsToWorkspace.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/slave/filesystem/CopyReportsToWorkspace.java
@@ -1,0 +1,60 @@
+package net.praqma.jenkins.plugin.prqa.notifier.slave.filesystem;
+
+import hudson.remoting.VirtualChannel;
+import jenkins.MasterToSlaveFileCallable;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+
+import static net.praqma.prqa.reports.ReportType.*;
+
+public class CopyReportsToWorkspace extends MasterToSlaveFileCallable<Boolean> implements Serializable {
+
+    private final String qaProject;
+
+    public CopyReportsToWorkspace(String qaProject) {
+        this.qaProject = qaProject;
+    }
+
+    @Override
+    public Boolean invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
+
+        final String reportsPath = "prqa/reports";
+        File qaFReports;
+
+        if (StringUtils.isEmpty(qaProject)) {
+            qaFReports = new File(reportsPath);
+        } else {
+            qaFReports = new File(qaProject + "/" + reportsPath);
+        }
+
+        if (!qaFReports.isDirectory()) {
+            qaFReports = new File(f + "/" + reportsPath);
+        }
+
+        if (!qaFReports.isDirectory()) {
+            return Boolean.FALSE;
+        }
+
+        File[] files = qaFReports.listFiles();
+        assert files != null;
+
+        for (File reportFile : files) {
+            if (containsReportName(reportFile.getName())) {
+                FileUtils.copyFileToDirectory(reportFile, f);
+            }
+        }
+
+        return Boolean.TRUE;
+    }
+
+    private boolean containsReportName(String fileName) {
+        return fileName.contains(CRR.name()) ||
+                fileName.contains(SUR.name()) ||
+                fileName.contains(RCR.name()) ||
+                fileName.contains(MDR.name());
+    }
+}

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/slave/filesystem/DeleteReportsFromWorkspace.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/notifier/slave/filesystem/DeleteReportsFromWorkspace.java
@@ -1,0 +1,34 @@
+package net.praqma.jenkins.plugin.prqa.notifier.slave.filesystem;
+
+import hudson.remoting.VirtualChannel;
+import jenkins.MasterToSlaveFileCallable;
+import net.praqma.jenkins.plugin.prqa.notifier.ReportFileFilter;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+
+public class DeleteReportsFromWorkspace extends MasterToSlaveFileCallable<Boolean> implements Serializable {
+
+    public DeleteReportsFromWorkspace() {
+    }
+
+    @Override
+    public Boolean invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
+
+        File[] files = f.listFiles(new ReportFileFilter());
+
+        if (files == null) {
+            return Boolean.TRUE;
+        }
+
+        for (File report : files) {
+            if (!report.delete()) {
+                return Boolean.FALSE;
+            }
+        }
+
+        return Boolean.TRUE;
+    }
+
+}

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/setup/QACToolSuite.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/setup/QACToolSuite.java
@@ -30,12 +30,16 @@ import hudson.tools.ToolInstallation;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import java.util.HashMap;
+import java.util.Map;
+
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.Nonnull;
 
 /**
  * 
@@ -79,8 +83,8 @@ public class QACToolSuite extends ToolInstallation implements PRQAToolSuite {
 
 	public HashMap<String, String> convert(EnvVars vars) {
 		HashMap<String, String> varsMap = new HashMap<String, String>();
-		for (String s : vars.keySet()) {
-			varsMap.put(s, vars.get(s));
+		for (Map.Entry<String, String> s : vars.entrySet()) {
+			varsMap.put(s.getKey(), s.getValue());
 		}
 		return varsMap;
 	}
@@ -120,7 +124,12 @@ public class QACToolSuite extends ToolInstallation implements PRQAToolSuite {
 		}
 
 		@Override
-		public QACToolSuite newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+		public QACToolSuite newInstance(StaplerRequest req, @Nonnull JSONObject formData) throws FormException {
+
+			if (req == null) {
+				throw new FormException(new Exception("Bad request"), "Bad request");
+			}
+
 			QACToolSuite suite = req.bindJSON(QACToolSuite.class, formData);
 
 			save();

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/setup/QACToolSuite.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/setup/QACToolSuite.java
@@ -29,9 +29,6 @@ import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import java.util.HashMap;
-import java.util.Map;
-
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
@@ -40,6 +37,8 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * 
@@ -127,7 +126,7 @@ public class QACToolSuite extends ToolInstallation implements PRQAToolSuite {
 		public QACToolSuite newInstance(StaplerRequest req, @Nonnull JSONObject formData) throws FormException {
 
 			if (req == null) {
-				throw new FormException(new Exception("Bad request"), "Bad request");
+				throw new FormException(new Exception("Bad request"), "Request is null");
 			}
 
 			QACToolSuite suite = req.bindJSON(QACToolSuite.class, formData);

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/setup/QAFrameworkInstallationConfiguration.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/setup/QAFrameworkInstallationConfiguration.java
@@ -12,10 +12,7 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import jenkins.model.Jenkins;
 import net.praqma.prqa.products.QACli;
@@ -28,6 +25,8 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import com.google.common.base.Strings;
+
+import javax.annotation.Nonnull;
 
 public class QAFrameworkInstallationConfiguration extends ToolInstallation implements PRQAToolSuite, NodeSpecific<QAFrameworkInstallationConfiguration> {
 
@@ -57,8 +56,8 @@ public class QAFrameworkInstallationConfiguration extends ToolInstallation imple
 
 	public HashMap<String, String> convert(EnvVars vars) {
 		HashMap<String, String> varsMap = new HashMap<String, String>();
-		for (String s : vars.keySet()) {
-			varsMap.put(s, vars.get(s));
+		for (Map.Entry<String, String> s : vars.entrySet()) {
+			varsMap.put(s.getKey(), s.getValue());
 		}
 		return varsMap;
 	}
@@ -103,7 +102,12 @@ public class QAFrameworkInstallationConfiguration extends ToolInstallation imple
 		}
 
 		@Override
-		public QAFrameworkInstallationConfiguration newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+		public QAFrameworkInstallationConfiguration newInstance(StaplerRequest req, @Nonnull JSONObject formData) throws FormException {
+
+			if (req == null) {
+				throw new FormException(new Exception("Bad request"), "Bad request");
+			}
+
 			QAFrameworkInstallationConfiguration suite = req.bindJSON(QAFrameworkInstallationConfiguration.class, formData);
 
 			save();

--- a/src/main/java/net/praqma/jenkins/plugin/prqa/threshold/AbstractThreshold.java
+++ b/src/main/java/net/praqma/jenkins/plugin/prqa/threshold/AbstractThreshold.java
@@ -27,6 +27,8 @@ import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import jenkins.model.Jenkins;
@@ -37,7 +39,7 @@ import net.praqma.prqa.status.PRQAComplianceStatus;
  * 
  * @author mads
  */
-public abstract class AbstractThreshold implements Describable<AbstractThreshold>, ExtensionPoint {
+public abstract class AbstractThreshold implements Describable<AbstractThreshold>, ExtensionPoint, Serializable {
 
 	public final Boolean improvement;
 

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/globalconfig/PRQAGlobalConfig/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/globalconfig/PRQAGlobalConfig/config.jelly
@@ -1,79 +1,86 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-                        
+<?jelly escape-by-default='true'?>
+<j:jelly
+        xmlns:j="jelly:core"
+        xmlns:f="/lib/form"
+>
+
     <f:section title="${%PRQA QA·Verify Configuration}">
-        <f:entry title="${%QA·Verify Servers}" description="${%List of available QA·Verify Servers}" help="/plugin/prqa-plugin/config/help-PRQAPluginGlobalConfiguration.html">
-            <f:repeatable var="servers" items="${instance.servers}">
-                <table>
-                <tr>
-                    <td>
-                        <f:label for="servers.configurationName">${%Configuration name}</f:label>
-                    </td>
-                    <td>
-                        <f:textbox name="servers.configurationName" field="configurationName" value="${servers.configurationName}" default="Configuration name"></f:textbox>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <f:label for="servers.hostName">${%Host name}</f:label>
-                    </td>
-                    <td>
-                        <f:textbox name="servers.hostName" field="hostName" value="${servers.hostName}" default="localhost"></f:textbox>
-                    </td>
-                </tr>
-                <tr>
-                    <td>        
-                        <f:label for="servers.userName">${%User name}</f:label>
-                    </td>
-                    <td>
-                        <f:textbox name="servers.userName" field="userName" value="${servers.userName}" default="upload"></f:textbox>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <f:label for="servers.password">${%Password}</f:label>
-                    </td>
-                    <td>
-                        <f:password name="servers.password" field="password" value="${servers.password}" ></f:password>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <f:label for="servers.portNumber">${%Upload port number}</f:label>
-                    </td>
-                    <td>
-                        <f:textbox name="servers.portNumber" field="portNumber" value="${servers.portNumber}" default="22230">${servers.portNumber}</f:textbox>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <f:label for="serverconfig.viewerPortNumber">${%View server port number}</f:label>
-                    </td>
-                    <td>
-                        <f:textbox name="serverconfig.viewerPortNumber" field="viewerPortNumber" value="${servers.viewerPortNumber}" default="8080">${servers.viewerPortNumber}</f:textbox>
-                    </td>
-                </tr>
-    
-                <tr>
-                    <td>
-                        <f:label for="servers.protocol">${%View server protocol}</f:label>
-                    </td>
-                    <td>
-                        <j:set var="protokol" value="${instance.getViewServerProtocols()}"/>
-                        <select class="protocol" name="protocol">
-                            <j:forEach var="l" items="${protokol}">
-                                <f:option selected="${servers.protocol.equals(l.toString())}" value="${l}">${l}</f:option>
+        <f:entry title="${%QA·Verify Servers}"
+                 description="${%List of available QA·Verify Servers}"
+                 help="/plugin/prqa-plugin/config/help-PRQAPluginGlobalConfiguration.html">
+            <f:repeatable var="servers"
+                          items="${instance.servers}">
+                <table width="100%">
+
+                    <f:entry field="servers.configurationName"
+                             title="${%Configuration name}">
+                        <f:textbox name="servers.configurationName"
+                                   field="configurationName"
+                                   value="${servers.configurationName}"
+                                   default="Configuration name"/>
+                    </f:entry>
+
+                    <f:entry field="servers.hostName"
+                             title="${%Host name}">
+                        <f:textbox name="servers.hostName"
+                                   field="hostName"
+                                   value="${servers.hostName}"
+                                   default="localhost"/>
+                    </f:entry>
+
+                    <f:entry field="servers.userName"
+                             title="${%User name}">
+                        <f:textbox name="servers.userName"
+                                   field="userName"
+                                   value="${servers.userName}"
+                                   default="upload"/>
+                    </f:entry>
+
+                    <f:entry field="servers.password"
+                             title="${%Password}">
+                        <f:password name="servers.password"
+                                    field="password"
+                                    value="${servers.password}"/>
+                    </f:entry>
+
+                    <f:entry field="servers.portNumber"
+                             title="${%Upload port number}">
+                        <f:textbox name="servers.portNumber"
+                                   field="portNumber"
+                                   value="${servers.portNumber}"
+                                   default="22230">
+                        </f:textbox>
+                    </f:entry>
+
+
+                    <f:entry field="serverconfig.viewerPortNumber"
+                             title="${%View server port number}">
+                        <f:textbox name="serverconfig.viewerPortNumber"
+                                   field="viewerPortNumber"
+                                   value="${servers.viewerPortNumber}"
+                                   default="8080">
+                        </f:textbox>
+                    </f:entry>
+
+                    <f:entry field="servers.protocol"
+                             title="${%View server protocol}">
+                        <j:set var="protokol"
+                               value="${instance.getViewServerProtocols()}"/>
+                        <select class="protocol"
+                                name="protocol">
+                            <j:forEach var="l"
+                                       items="${protokol}">
+                                <f:option selected="${servers.protocol.equals(l.toString())}"
+                                          value="${l}">${l}
+                                </f:option>
                             </j:forEach>
                         </select>
-                    </td>
-                </tr>
+                    </f:entry>
 
-                <tr>
-                    <td>
-                        <f:repeatableDeleteButton/>
-                    </td>
-                </tr>
                 </table>
+
+                <f:repeatableDeleteButton/>
+
             </f:repeatable>
         </f:entry>
     </f:section>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQABuildAction/index.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQABuildAction/index.jelly
@@ -1,4 +1,5 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
-	xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
-	xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:u="/util">
+<?jelly escape-by-default='true'?>
+<j:jelly
+        xmlns:j="jelly:core"
+>
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQABuildAction/summary.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQABuildAction/summary.jelly
@@ -1,6 +1,8 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
-	xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
-	xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:u="/util">
-<j:set var="latestAction" value="${from.getBuildActionStatus()}"/>
-${latestAction.toHtml()}
+<?jelly escape-by-default='true'?>
+<j:jelly
+        xmlns:j="jelly:core"
+>
+    <j:set var="latestAction"
+           value="${from.getBuildActionStatus()}"/>
+    <j:out value="${latestAction.toHtml()}"/>
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQANotifier/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQANotifier/config.jelly
@@ -20,7 +20,7 @@
     <f:block>
         <f:entry field="sourceQAFramework"
                  help="/plugin/prqa-plugin/config/help-configProductType.html">
-            <f:descriptorRadioList title="sourceQAFramework"
+            <f:descriptorRadioList title=""
                                    descriptors="${descriptor.getReportSources()}"
                                    varName="sourceQAFramework"
                                    instance="${instance.sourceQAFramework}"

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQANotifier/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQANotifier/config.jelly
@@ -1,28 +1,46 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    
+<?jelly escape-by-default='true'?>
+<j:jelly
+        xmlns:j="jelly:core"
+        xmlns:f="/lib/form"
+>
     <style>
         td.setting-name {
         vertical-align:middle;
-        }        
+        }
     </style>
-	
-    <f:entry title="${%Run PRQA Analysis only when build is successful}" field="runWhenSuccess" help="/plugin/prqa-plugin/config/help-runWhenSuccess.html">
-        <f:checkbox name="runWhenSuccess" value="${instance.runWhenSuccess}" checked="${instance.runWhenSuccess}"/>
-    </f:entry> 
-    
+
+    <f:entry title="${%Run PRQA Analysis only when build is successful}"
+             field="runWhenSuccess"
+             help="/plugin/prqa-plugin/config/help-runWhenSuccess.html">
+        <f:checkbox name="runWhenSuccess"
+                    value="${instance.runWhenSuccess}"
+                    checked="${instance.runWhenSuccess}"/>
+    </f:entry>
+
     <f:block>
-        <f:entry field="sourceQAFramework">
-            <f:descriptorRadioList descriptors="${descriptor.getReportSources()}" varName="sourceQAFramework" instance="${instance.sourceQAFramework}"  help="/plugin/prqa-plugin/config/help-configProductType.html"/>
+        <f:entry field="sourceQAFramework"
+                 help="/plugin/prqa-plugin/config/help-configProductType.html">
+            <f:descriptorRadioList title="sourceQAFramework"
+                                   descriptors="${descriptor.getReportSources()}"
+                                   varName="sourceQAFramework"
+                                   instance="${instance.sourceQAFramework}"
+            />
         </f:entry>
     </f:block>
-        
+
     <f:section title="Threshold">
-        <f:entry title="${%Message threshold level}" field="threshholdlevel">
+        <f:entry title="${%Message threshold level}"
+                 field="threshholdlevel">
             <f:select/>
         </f:entry>
-        <f:block> 
-            <f:hetero-list hasHeader="true" name="thresholdsDesc" addCaption="${%Add threshold}" deleteCaption="${%Remove threshold}" oneEach="true" descriptors="${descriptor.getThresholdSelections()}" items="${instance.thresholdsDesc}"/> 
+        <f:block>
+            <f:hetero-list hasHeader="true"
+                           name="thresholdsDesc"
+                           addCaption="${%Add threshold}"
+                           deleteCaption="${%Remove threshold}"
+                           oneEach="true"
+                           descriptors="${descriptor.getThresholdSelections()}"
+                           items="${instance.thresholdsDesc}"/>
         </f:block>
     </f:section>
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAProjectAction/floatingBox.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAProjectAction/floatingBox.jelly
@@ -1,29 +1,36 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
-    <j:set var="latestAction" value="${from.latestActionInProject}"/>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    <j:set var="latestAction"
+           value="${from.latestActionInProject}"/>
     <j:if test="${latestAction != null}">
         <j:choose>
             <j:when test="${latestAction.previousAction != null}">
                 <div>
-                    <j:set var="publisher" value="${from.getLatestActionInProject().getPublisher()}"></j:set>
-                    <j:set var="cnt" value="${publisher.getSupportedGraphs()}"></j:set>
-                    <j:forEach var="pgraph" items="${publisher.getSupportedGraphs()}">
-                        <img style="margin-left:20px;" src="${from.urlName}/reportGraphs?width=400&amp;height=233&amp;graph=${pgraph.getClass().getSimpleName()}&amp;tsetting=${publisher.threshholdlevel}"/>
+                    <j:set var="publisher"
+                           value="${from.getLatestActionInProject().getPublisher()}"/>
+                    <j:set var="cnt"
+                           value="${publisher.getSupportedGraphs()}"/>
+                    <j:forEach var="pgraph"
+                               items="${publisher.getSupportedGraphs()}">
+                        <img style="margin-left:20px;"
+                             src="${from.urlName}/reportGraphs?width=400&amp;height=233&amp;graph=${pgraph.getClass().getSimpleName()}&amp;tsetting=${publisher.threshholdlevel}"/>
                     </j:forEach>
                 </div>
             </j:when>
             <j:otherwise>
-            <div id="marginme" style="margin-right:150px">
-                <h3>${%Not enough data}</h3>
-                <p>${%The project needs to have at least two builds with data to generate a graph with results.}</p>
-            </div>
+                <div id="marginme"
+                     style="margin-right:150px">
+                    <h3>${%Not enough data}</h3>
+                    <p>${%The project needs to have at least two builds with data to generate a graph with results.}</p>
+                </div>
             </j:otherwise>
         </j:choose>
     </j:if>
     <j:if test="${latestAction eq null}">
-        <div id="marginme" style="margin-right:150px">
+        <div id="marginme"
+             style="margin-right:150px">
             <h3>${%Not enough data}</h3>
             <p>${%The project needs to have at least two builds with data to generate a graph with results.}</p>
         </div>
-    </j:if>   
+    </j:if>
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAProjectAction/index.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAProjectAction/index.jelly
@@ -1,25 +1,35 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
- <l:layout title="PRQA Results">
-     <l:main-panel>             
-             
-        <j:set var="latestAction" value="${it.getLatestActionInProject()}"></j:set>
-        <j:set var="publisher" value="${latestAction.getPublisher()}"></j:set>
-        <j:set var="reportType" value="${publisher.getReportType()}"></j:set>
-        <j:set var="drawGraphs" value="${it.isDrawGraphs()}"></j:set>
-        <div>
-            <h3>${%PRQA Results}</h3>            
-            <p>${%Visit} <a href="http://www.programmingresearch.com/">Programming Research</a> ${%website for additional product information}</p>
-            <j:if test="${drawGraphs == true}">             
-                <j:forEach var="pgraph" items="${publisher.getSupportedGraphs()}">
-                    <img style="margin-left:20px;" src="reportGraphs?width=600&amp;height=340&amp;graph=${pgraph.getClass().getSimpleName()}&amp;tsetting=${publisher.threshholdlevel}"/>
-                </j:forEach>
-            </j:if>
-            <j:if test="${drawGraphs == false}">
-            <p>${%Currently there is not enough PRQA data to generate a result graph. You need to have at least 2 succesful builds in order for the graphs to be created}</p>
-            </j:if> 
-            
-        </div>
-    </l:main-panel>
-</l:layout>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:l="/lib/layout">
+    <l:layout title="PRQA Results">
+        <l:main-panel>
+
+            <j:set var="latestAction"
+                   value="${it.getLatestActionInProject()}"/>
+            <j:set var="publisher"
+                   value="${latestAction.getPublisher()}"/>
+            <j:set var="reportType"
+                   value="${publisher.getReportType()}"/>
+            <j:set var="drawGraphs"
+                   value="${it.isDrawGraphs()}"/>
+            <div>
+                <h3>${%PRQA Results}</h3>
+                <p>${%Visit} <a href="http://www.programmingresearch.com/">Programming Research</a> ${%website for additional product information}
+                </p>
+                <j:if test="${drawGraphs == true}">
+                    <j:forEach var="pgraph"
+                               items="${publisher.getSupportedGraphs()}">
+                        <img style="margin-left:20px;"
+                             src="reportGraphs?width=600&amp;height=340&amp;graph=${pgraph.getClass().getSimpleName()}&amp;tsetting=${publisher.threshholdlevel}"/>
+                    </j:forEach>
+                </j:if>
+                <j:if test="${drawGraphs == false}">
+                    <p>
+                        ${%Currently there is not enough PRQA data to generate a result graph. You need to have at least 2 succesful builds in order for the graphs to be created}
+                    </p>
+                </j:if>
+
+            </div>
+        </l:main-panel>
+    </l:layout>
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAProjectAction/jobMain.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAProjectAction/jobMain.jelly
@@ -1,17 +1,22 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
 
-	    	<h3>${%PRQA Links of interest}</h3>
-	    	<ul>
-	        	<j:set var="conf" value="${it.getConfiguration()}"/>
-	        		<j:choose>
-	            		<j:when test="${conf != null}">
-	                		<li>${%PRQA View server location:} <a href="${conf.getFullUrl()}">${%QA&#xb7;Verify server}</a></li>
-	            		</j:when>
-	            		<j:otherwise>
-	                		<li>${%No QA&#xb7;Verify servers defined} - click <a href="${rootURL}/configure">${%here}</a></li>
-	            		</j:otherwise> 
-	        		</j:choose>        
-	    	</ul>
-	    ${it.getLatestActionInProject().getBuildActionStatus(PRQAComplianceStatus.class).toHtml()}         
+    <h3>${%PRQA Links of interest}</h3>
+    <ul>
+        <j:set var="conf"
+               value="${it.getConfiguration()}"/>
+        <j:choose>
+            <j:when test="${conf != null}">
+                <li>${%PRQA View server location:}
+                    <a href="${conf.getFullUrl()}">${%QA&#xb7;Verify server}</a>
+                </li>
+            </j:when>
+            <j:otherwise>
+                <li>${%No QA&#xb7;Verify servers defined} - click
+                    <a href="${rootURL}/configure">${%here}</a>
+                </li>
+            </j:otherwise>
+        </j:choose>
+    </ul>
+    <j:out value="${it.getLatestActionInProject().getBuildActionStatus(PRQAComplianceStatus.class).toHtml()}"/>
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAReportFileListSource/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAReportFileListSource/config.jelly
@@ -1,12 +1,17 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-            
-    <f:entry title="${%File list path}" field="fileList" help="/plugin/prqa-plugin/config/help-configFileList.html">
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
+
+    <f:entry title="${%File list path}"
+             field="fileList"
+             help="/plugin/prqa-plugin/config/help-configFileList.html">
         <f:textbox/>
     </f:entry>
-    
-    <f:entry title="${%Settings file path}" field="settingsFile" help="/plugin/prqa-plugin/config/help-configFileList.html">
-        <f:textbox/> 
-    </f:entry>    
-    
+
+    <f:entry title="${%Settings file path}"
+             field="settingsFile"
+             help="/plugin/prqa-plugin/config/help-configFileList.html">
+        <f:textbox/>
+    </f:entry>
+
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAReportPRQAToolSource/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAReportPRQAToolSource/config.jelly
@@ -21,7 +21,7 @@
                 <f:descriptorRadioList descriptors="${descriptor.getFileProjectSources()}"
                                        varName="fileProjectSource"
                                        instance="${instance.fileProjectSource}"
-                                       title="fileProjectSource"/>
+                                       title=""/>
             </f:entry>
 
         </f:block>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAReportPRQAToolSource/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAReportPRQAToolSource/config.jelly
@@ -1,92 +1,154 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-         
- <style>      
-table.outer{
-		width:100%;
-		}
-    </style>    
-     <f:section title="Analyzer Setup">
-     
-     
-     
-     <f:entry title="${%PRQA Tool Installation}" field="product" help="/plugin/prqa-plugin/config/help-configProductType.html">
-        <f:select/>            
-     </f:entry>
-      <f:block>    	
-        <f:entry field="fileProjectSource">
-            <f:descriptorRadioList descriptors="${descriptor.getFileProjectSources()}" varName="fileProjectSource" instance="${instance.fileProjectSource}"  help="/plugin/prqa-plugin/config/help-configProductType.html"/>
-        </f:entry>                      
-      </f:block>
-      
-      <f:entry title="${%Perform Cross-Module analysis}" field="performCrossModuleAnalysis" help="/plugin/prqa-plugin/config/help-configPerformCMA.html">
-            <f:checkbox  name="performCrossModuleAnalysis" value="${instance.performCrossModuleAnalysis}" checked="${instance.performCrossModuleAnalysis}"/>
-      </f:entry>
-      
-      <f:entry title="${%Enable dependency based analysis}" field="enableDependencyMode" help="/plugin/prqa-plugin/config/help-configEnableDMode.html">
-            <f:checkbox name="enableDependencyMode" value="${instance.enableDependencyMode}" checked="${instance.enableDependencyMode}"/>
-      </f:entry>
-      
-       <f:entry title="${%Enable dataflow analysis}" field="enableDataFlowAnalysis" help="/plugin/prqa-plugin/config/help-configEnableDFA.html">
-            <f:checkbox name="enableDataFlowAnalysis" value="${instance.enableDataFlowAnalysis}" checked="${instance.enableDataFlowAnalysis}"/>
-      </f:entry>
-          <f:block> 
-          <table>
-              <f:optionalBlock name="generateCrr" title="${%Code Review Report}" checked="${instance.generateCrr}" inline="true" />
-              <f:optionalBlock name="generateSup" title="${%Suppression Report}" checked="${instance.generateSup}" inline="true" />
-          </table>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
+
+    <style>
+        table.outer{
+        width:100%;
+        }
+    </style>
+    <f:section title="Analyzer Setup">
+
+
+        <f:entry title="${%PRQA Tool Installation}"
+                 field="product"
+                 help="/plugin/prqa-plugin/config/help-configProductType.html">
+            <f:select/>
+        </f:entry>
+        <f:block>
+            <f:entry field="fileProjectSource"
+                     help="/plugin/prqa-plugin/config/help-configProductType.html">
+                <f:descriptorRadioList descriptors="${descriptor.getFileProjectSources()}"
+                                       varName="fileProjectSource"
+                                       instance="${instance.fileProjectSource}"
+                                       title="fileProjectSource"/>
+            </f:entry>
+
+        </f:block>
+
+        <f:entry title="${%Perform Cross-Module analysis}"
+                 field="performCrossModuleAnalysis"
+                 help="/plugin/prqa-plugin/config/help-configPerformCMA.html">
+            <f:checkbox name="performCrossModuleAnalysis"
+                        value="${instance.performCrossModuleAnalysis}"
+                        checked="${instance.performCrossModuleAnalysis}"/>
+        </f:entry>
+
+        <f:entry title="${%Enable dependency based analysis}"
+                 field="enableDependencyMode"
+                 help="/plugin/prqa-plugin/config/help-configEnableDMode.html">
+            <f:checkbox name="enableDependencyMode"
+                        value="${instance.enableDependencyMode}"
+                        checked="${instance.enableDependencyMode}"/>
+        </f:entry>
+
+        <f:entry title="${%Enable dataflow analysis}"
+                 field="enableDataFlowAnalysis"
+                 help="/plugin/prqa-plugin/config/help-configEnableDFA.html">
+            <f:checkbox name="enableDataFlowAnalysis"
+                        value="${instance.enableDataFlowAnalysis}"
+                        checked="${instance.enableDataFlowAnalysis}"/>
+        </f:entry>
+        <f:block>
+            <table>
+                <f:optionalBlock name="generateCrr"
+                                 title="${%Code Review Report}"
+                                 checked="${instance.generateCrr}"
+                                 inline="true"/>
+                <f:optionalBlock name="generateSup"
+                                 title="${%Suppression Report}"
+                                 checked="${instance.generateSup}"
+                                 inline="true"/>
+            </table>
         </f:block>
         <f:block>
-        <table class="outer">
-        <f:optionalBlock name="publishToQAV" title="${%Upload results to QA&#xb7;Verify}" help="/plugin/prqa-plugin/config/help-configUploadQAV.html" checked="${instance.publishToQAV}" inline="true">
+            <table class="outer">
+                <f:optionalBlock name="publishToQAV"
+                                 title="${%Upload results to QA&#xb7;Verify}"
+                                 help="/plugin/prqa-plugin/config/help-configUploadQAV.html"
+                                 checked="${instance.publishToQAV}"
+                                 inline="true">
 
-                <j:set var="zervers" value="${descriptor.getServers()}"/>
-                <f:entry title="${%Select server configuration}" help="/plugin/prqa-plugin/config/help-configServerSelect.html" field="chosenServers">
-                    <select multiple="true" class="chosenServers" name="chosenServers">
-                        <j:forEach var="l" items="${zervers}">
-                            <f:option selected="${instance.chosenServers.contains(l.toString())}" value="${l}">${l}</f:option>
-                        </j:forEach>
-                    </select>
-                </f:entry>
+                    <j:set var="zervers"
+                           value="${descriptor.getServers()}"/>
+                    <f:entry title="${%Select server configuration}"
+                             help="/plugin/prqa-plugin/config/help-configServerSelect.html"
+                             field="chosenServers">
+                        <select multiple="true"
+                                class="chosenServers"
+                                name="chosenServers">
+                            <j:forEach var="l"
+                                       items="${zervers}">
+                                <f:option selected="${instance.chosenServers.contains(l.toString())}"
+                                          value="${l}">${l}
+                                </f:option>
+                            </j:forEach>
+                        </select>
+                    </f:entry>
 
-                <j:set var="zettings" value="${descriptor.getUploadSettings()}"/>
-                <f:entry title="${%Code upload settings}" help="/plugin/prqa-plugin/config/codeUpload.html" field="codeUploadSetting">
-                    <table class="inner">
-                    <j:forEach var="l" items="${zettings}">
-                        <tr>
-                        <td><f:label><span style="vertical-align:middle">${l}</span></f:label></td>
+                    <j:set var="zettings"
+                           value="${descriptor.getUploadSettings()}"/>
+                    <f:entry title="${%Code upload settings}"
+                             help="/plugin/prqa-plugin/config/codeUpload.html"
+                             field="codeUploadSetting">
+                        <table class="inner">
+                            <j:forEach var="l"
+                                       items="${zettings}">
+                                <tr>
+                                    <td>
+                                        <f:entry>
+                                            <span style="vertical-align:middle">${l}</span>
+                                        </f:entry>
+                                    </td>
 
-                        <j:choose>         
-                                <j:when test="${instance.codeUploadSetting.equals(l)}">
-                                    <td style="vertical-align:middle"><f:radio name="codeUploadSetting" value="${l}" checked="true"/></td>
-                                </j:when>
-                                <j:otherwise>
-                                    <td style="vertical-align:middle"><f:radio name="codeUploadSetting" value="${l}" checked="false"/></td>
-                                </j:otherwise>
-                        </j:choose>                        
-                        </tr>
-                    </j:forEach>
-                    </table>
-                </f:entry>
+                                    <j:choose>
+                                        <j:when test="${instance.codeUploadSetting.equals(l)}">
+                                            <td style="vertical-align:middle">
+                                                <f:radio name="codeUploadSetting"
+                                                         value="${l}"
+                                                         checked="true"/>
+                                            </td>
+                                        </j:when>
+                                        <j:otherwise>
+                                            <td style="vertical-align:middle">
+                                                <f:radio name="codeUploadSetting"
+                                                         value="${l}"
+                                                         checked="false"/>
+                                            </td>
+                                        </j:otherwise>
+                                    </j:choose>
+                                </tr>
+                            </j:forEach>
+                        </table>
+                    </f:entry>
 
-                <f:entry title="${%QA&#xb7;Verify project name}" field="qaVerifyProjectName" help="/plugin/prqa-plugin/config/help-configQAVPname.html">
-                    <f:textbox value="${instance.qaVerifyProjectName}"/>
-                </f:entry>
+                    <f:entry title="${%QA&#xb7;Verify project name}"
+                             field="qaVerifyProjectName"
+                             help="/plugin/prqa-plugin/config/help-configQAVPname.html">
+                        <f:textbox value="${instance.qaVerifyProjectName}"/>
+                    </f:entry>
 
-                <f:entry title="${%VCS Config file location}" field="vcsConfigXml" help="/plugin/prqa-plugin/config/help-configVCSConfig.html">
-                    <f:textbox value="${instance.vcsConfigXml}"/>
-                </f:entry>
+                    <f:entry title="${%VCS Config file location}"
+                             field="vcsConfigXml"
+                             help="/plugin/prqa-plugin/config/help-configVCSConfig.html">
+                        <f:textbox value="${instance.vcsConfigXml}"/>
+                    </f:entry>
 
-                <f:entry title="${%Source origin}" field="sourceOrigin" help="/plugin/prqa-plugin/config/help-configSourceOrigin.html">
-                    <f:textbox value="${instance.sourceOrigin}"/>
-                </f:entry>
+                    <f:entry title="${%Source origin}"
+                             field="sourceOrigin"
+                             help="/plugin/prqa-plugin/config/help-configSourceOrigin.html">
+                        <f:textbox value="${instance.sourceOrigin}"/>
+                    </f:entry>
 
-                <f:entry title="${%Use single snapshot mode}" field="singleSnapshotMode" help="/plugin/prqa-plugin/config/help-configSingleMode.html">
-                    <f:checkbox value="${instance.singleSnapshotMode}" checked="${instance.singleSnapshotMode}"/>
-                </f:entry>
+                    <f:entry title="${%Use single snapshot mode}"
+                             field="singleSnapshotMode"
+                             help="/plugin/prqa-plugin/config/help-configSingleMode.html">
+                        <f:checkbox value="${instance.singleSnapshotMode}"
+                                    checked="${instance.singleSnapshotMode}"/>
+                    </f:entry>
 
-        </f:optionalBlock>
-         </table>
+                </f:optionalBlock>
+            </table>
         </f:block>
-     </f:section>
+    </f:section>
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAReportProjectFileSource/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/PRQAReportProjectFileSource/config.jelly
@@ -1,8 +1,11 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-        
-    <f:entry title="${%Project file path}" field="projectFile" help="/plugin/prqa-plugin/config/help-configProjectFile.html">
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
+
+    <f:entry title="${%Project file path}"
+             field="projectFile"
+             help="/plugin/prqa-plugin/config/help-configProjectFile.html">
         <f:textbox/>
     </f:entry>
-    
+
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/QAFrameworkPostBuildActionSetup/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/notifier/QAFrameworkPostBuildActionSetup/config.jelly
@@ -1,51 +1,87 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-   
-    <style>      
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
+
+    <style>
         table.outer{
         width:100%;
         }
-    </style> 
+    </style>
     <f:section title="Setup">
-   
+
         <f:block>
             <table class="outer">
-                <f:entry title="${%PRQA·Framework Installation}" field="qaInstallation" help="/plugin/prqa-plugin/config/help-qaInstallation.html">
+                <f:entry title="${%PRQA·Framework Installation}"
+                         field="qaInstallation"
+                         help="/plugin/prqa-plugin/config/help-qaInstallation.html">
                     <f:select/>
                 </f:entry>
-                <f:entry title="${%PRQA·Framework Project}" field="qaProject" help="/plugin/prqa-plugin/config/help-qaProject.html">
+                <f:entry title="${%PRQA·Framework Project}"
+                         field="qaProject"
+                         help="/plugin/prqa-plugin/config/help-qaProject.html">
                     <f:textbox/>
                 </f:entry>
 
                 <f:block>
-                    <f:optionalBlock name="loginToQAV" title="${%QA&#xb7;Verify Server Connection}" help="/plugin/prqa-plugin/config/help-configQAVServerConnection.html" checked="${instance.loginToQAV}" inline="true">
-                        <j:set var="zervers" value="${descriptor.getServers()}"/>
-                        <f:entry title="${%Select server configuration}" help="/plugin/prqa-plugin/config/help-configServerSelect.html" field="chosenServers">
-                           <select multiple="true" class="chosenServers" name="chosenServers">
-                                <j:forEach var="l" items="${zervers}">
-                                    <f:option selected="${instance.chosenServers.contains(l.toString())}" value="${l}">${l}</f:option>
+                    <f:optionalBlock name="loginToQAV"
+                                     title="${%QA&#xb7;Verify Server Connection}"
+                                     help="/plugin/prqa-plugin/config/help-configQAVServerConnection.html"
+                                     checked="${instance.loginToQAV}"
+                                     inline="true">
+                        <j:set var="zervers"
+                               value="${descriptor.getServers()}"/>
+                        <f:entry title="${%Select server configuration}"
+                                 help="/plugin/prqa-plugin/config/help-configServerSelect.html"
+                                 field="chosenServers">
+                            <select multiple="true"
+                                    class="chosenServers"
+                                    name="chosenServers">
+                                <j:forEach var="l"
+                                           items="${zervers}">
+                                    <f:option selected="${instance.chosenServers.contains(l.toString())}"
+                                              value="${l}">${l}
+                                    </f:option>
                                 </j:forEach>
                             </select>
                         </f:entry>
-                        <f:optionalBlock name="downloadUnifiedProjectDefinition" title="${%Download Unified Project Definition}" help="/plugin/prqa-plugin/config/help-downloadUnifiedProject.html" checked="${instance.downloadUnifiedProjectDefinition}" inline="true">
-                            <f:entry title="${%Unified Project Name}" field="unifiedProjectName" help="/plugin/prqa-plugin/config/help-unifiedProjectName.html">
+                        <f:optionalBlock name="downloadUnifiedProjectDefinition"
+                                         title="${%Download Unified Project Definition}"
+                                         help="/plugin/prqa-plugin/config/help-downloadUnifiedProject.html"
+                                         checked="${instance.downloadUnifiedProjectDefinition}"
+                                         inline="true">
+                            <f:entry title="${%Unified Project Name}"
+                                     field="unifiedProjectName"
+                                     help="/plugin/prqa-plugin/config/help-unifiedProjectName.html">
                                 <f:textbox value="${instance.unifiedProjectName}"/>
                             </f:entry>
                         </f:optionalBlock>
-                        <f:optionalBlock name="publishToQAV" title="${%Upload results to QA&#xb7;Verify}" help="/plugin/prqa-plugin/config/help-configUploadQAV.html" checked="${instance.publishToQAV}" inline="true">
-                            <f:entry title="${%Upload only when build is stable}" field="uploadWhenStable" help="/plugin/prqa-plugin/config/help-qaUploadWhenStable.html">
-                                <f:checkbox name="uploadWhenStable" value="${instance.uploadWhenStable}" checked="${instance.uploadWhenStable}"/>
+                        <f:optionalBlock name="publishToQAV"
+                                         title="${%Upload results to QA&#xb7;Verify}"
+                                         help="/plugin/prqa-plugin/config/help-configUploadQAV.html"
+                                         checked="${instance.publishToQAV}"
+                                         inline="true">
+                            <f:entry title="${%Upload only when build is stable}"
+                                     field="uploadWhenStable"
+                                     help="/plugin/prqa-plugin/config/help-qaUploadWhenStable.html">
+                                <f:checkbox name="uploadWhenStable"
+                                            value="${instance.uploadWhenStable}"
+                                            checked="${instance.uploadWhenStable}"/>
                             </f:entry>
 
-                            <f:entry title="${%Project name}" field="qaVerifyProjectName" help="/plugin/prqa-plugin/config/help-configQAVPname.html">
+                            <f:entry title="${%Project name}"
+                                     field="qaVerifyProjectName"
+                                     help="/plugin/prqa-plugin/config/help-configQAVPname.html">
                                 <f:textbox value="${instance.qaVerifyProjectName}"/>
                             </f:entry>
 
-                            <f:entry title="${%Snapshot name}" field="uploadSnapshotName" help="/plugin/prqa-plugin/config/help-configSnapShotName.html">
+                            <f:entry title="${%Snapshot name}"
+                                     field="uploadSnapshotName"
+                                     help="/plugin/prqa-plugin/config/help-configSnapShotName.html">
                                 <f:textbox value="${instance.uploadSnapshotName}"/>
                             </f:entry>
 
-                            <f:entry title="${%Upload Source Code}" field="uploadSourceCode">
+                            <f:entry title="${%Upload Source Code}"
+                                     field="uploadSourceCode">
                                 <f:select/>
                             </f:entry>
 
@@ -53,29 +89,62 @@
                     </f:optionalBlock>
                 </f:block>
 
-                <f:entry title="${%Enable Dependency Based Analysis}" field="enableDependencyMode" help="/plugin/prqa-plugin/config/help-qaDependencyMode.html">
-                    <f:checkbox name="enableDependencyMode" value="${instance.enableDependencyMode}" checked="${instance.enableDependencyMode}"/>
+                <f:entry title="${%Enable Dependency Based Analysis}"
+                         field="enableDependencyMode"
+                         help="/plugin/prqa-plugin/config/help-qaDependencyMode.html">
+                    <f:checkbox name="enableDependencyMode"
+                                value="${instance.enableDependencyMode}"
+                                checked="${instance.enableDependencyMode}"/>
                 </f:entry>
 
                 <f:block>
-                    <f:optionalBlock name="performCrossModuleAnalysis" title="Run Project Based CMA Analysis (prior to PRQA Framework 2.1.0)" help="/plugin/prqa-plugin/config/help-qaCMA.html" checked="${instance.performCrossModuleAnalysis}" inline="true">
+                    <f:optionalBlock name="performCrossModuleAnalysis"
+                                     title="Run Project Based CMA Analysis (prior to PRQA Framework 2.1.0)"
+                                     help="/plugin/prqa-plugin/config/help-qaCMA.html"
+                                     checked="${instance.performCrossModuleAnalysis}"
+                                     inline="true">
                     </f:optionalBlock>
                 </f:block>
 
                 <f:block>
-                    <f:optionalBlock name="generateCrr" title="${%Code Review Report}" checked="${instance.generateCrr}" inline="true" />
-                    <f:optionalBlock name="generateMdr" title="${%Metrics Data Report}" checked="${instance.generateMdr}" inline="true" />
-                    <f:optionalBlock name="generateSup" title="${%Suppression Report}" checked="${instance.generateSup}" inline="true" />
+                    <f:optionalBlock name="generateCrr"
+                                     title="${%Code Review Report}"
+                                     checked="${instance.generateCrr}"
+                                     inline="true"/>
+                    <f:optionalBlock name="generateMdr"
+                                     title="${%Metrics Data Report}"
+                                     checked="${instance.generateMdr}"
+                                     inline="true"/>
+                    <f:optionalBlock name="generateSup"
+                                     title="${%Suppression Report}"
+                                     checked="${instance.generateSup}"
+                                     inline="true"/>
                 </f:block>
 
                 <f:block>
-                    <f:optionalBlock name="analysisSettings" title="${%Analysis Settings}" help="/plugin/prqa-plugin/config/help-qaAnalysisSettings.html" checked="${instance.analysisSettings}" inline="true">
-                        <f:entry title="${%Stop Analysis Upon Failure}" field="stopWhenFail" help="/plugin/prqa-plugin/config/help-qaStopWhenFail.html">
-                            <f:checkbox name="stopWhenFail" value="${instance.stopWhenFail}" checked="${instance.stopWhenFail}"/>
+                    <f:optionalBlock name="analysisSettings"
+                                     title="${%Analysis Settings}"
+                                     help="/plugin/prqa-plugin/config/help-qaAnalysisSettings.html"
+                                     checked="${instance.analysisSettings}"
+                                     inline="true">
+                        <f:entry title="${%Stop Analysis Upon Failure}"
+                                 field="stopWhenFail"
+                                 help="/plugin/prqa-plugin/config/help-qaStopWhenFail.html">
+                            <f:checkbox name="stopWhenFail"
+                                        value="${instance.stopWhenFail}"
+                                        checked="${instance.stopWhenFail}"/>
                         </f:entry>
-                        <f:optionalBlock title="${%Generate Preprocessed Source}" name="generatePreprocess" help="/plugin/prqa-plugin/config/help-qaGeneratePreprocess.html" checked="${instance.generatePreprocess}" inline="true">
-                            <f:entry title="${%Assemble Support Analytic for failed Files}" field="assembleSupportAnalytics" help="/plugin/prqa-plugin/config/help-qaAssembleSupportAnalytics.html">
-                                <f:checkbox name="assembleSupportAnalytics" value="${instance.assembleSupportAnalytics}" checked="${instance.assembleSupportAnalytics}"/>
+                        <f:optionalBlock title="${%Generate Preprocessed Source}"
+                                         name="generatePreprocess"
+                                         help="/plugin/prqa-plugin/config/help-qaGeneratePreprocess.html"
+                                         checked="${instance.generatePreprocess}"
+                                         inline="true">
+                            <f:entry title="${%Assemble Support Analytic for failed Files}"
+                                     field="assembleSupportAnalytics"
+                                     help="/plugin/prqa-plugin/config/help-qaAssembleSupportAnalytics.html">
+                                <f:checkbox name="assembleSupportAnalytics"
+                                            value="${instance.assembleSupportAnalytics}"
+                                            checked="${instance.assembleSupportAnalytics}"/>
                             </f:entry>
                         </f:optionalBlock>
                     </f:optionalBlock>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/setup/QACToolSuite/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/setup/QACToolSuite/config.jelly
@@ -1,26 +1,33 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
     <style>
         .not-impl {
-            font-style:italic;
+        font-style:italic;
         }
     </style>
-    <f:entry title="${%Installation name}" field="name">
+    <f:entry title="${%Installation name}"
+             field="name">
         <f:textbox/>
     </f:entry>
-    <f:entry title="${%Product}" field="tool">
+    <f:entry title="${%Product}"
+             field="tool">
         <f:select/>
-    </f:entry>    
-    <f:entry title="${%Product installation path}" field="home">
+    </f:entry>
+    <f:entry title="${%Product installation path}"
+             field="home">
         <f:textbox/>
     </f:entry>
-    <f:entry title="${%QAR installation home}" field="qarHome">
+    <f:entry title="${%QAR installation home}"
+             field="qarHome">
         <f:textbox/>
     </f:entry>
-    <f:entry title="${%QAW installation home}" field="qawHome">
+    <f:entry title="${%QAW installation home}"
+             field="qawHome">
         <f:textbox/>
-    </f:entry>    
-    <f:entry title="${%QAV Client home}" field="qavHome">
+    </f:entry>
+    <f:entry title="${%QAV Client home}"
+             field="qavHome">
         <f:textbox/>
     </f:entry>
 
@@ -29,5 +36,5 @@
             <span class="not-impl">The install automatically feature is not implemented.</span>
         </td>
     </tr>
-    
+
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/setup/QACppToolSuite/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/setup/QACppToolSuite/config.jelly
@@ -1,19 +1,25 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    
-    <f:entry title="${%Installation name}" field="name">
-        <f:textbox></f:textbox>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
+
+    <f:entry title="${%Installation name}"
+             field="name">
+        <f:textbox/>
     </f:entry>
-    <f:entry title="${%QACpp home}" field="home">
-        <f:textbox></f:textbox>
+    <f:entry title="${%QACpp home}"
+             field="home">
+        <f:textbox/>
     </f:entry>
-    <f:entry title="${%QAR installation home}" field="qarHome">
-        <f:textbox></f:textbox>
+    <f:entry title="${%QAR installation home}"
+             field="qarHome">
+        <f:textbox/>
     </f:entry>
-    <f:entry title="${%QAW installation home}" field="qawHome">
-        <f:textbox></f:textbox>
-    </f:entry>    
-    <f:entry title="${%QAV Client home}" field="qavHome">
-        <f:textbox></f:textbox>
+    <f:entry title="${%QAW installation home}"
+             field="qawHome">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="${%QAV Client home}"
+             field="qavHome">
+        <f:textbox/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/setup/QAFrameworkInstallationConfiguration/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/setup/QAFrameworkInstallationConfiguration/config.jelly
@@ -1,15 +1,18 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
     <style>
         .not-impl {
-            font-style:italic;
+        font-style:italic;
         }
     </style>
-    
-    <f:entry title="${%PRQA·Framework Installation name}" field="qafName">
+
+    <f:entry title="${%PRQA·Framework Installation name}"
+             field="qafName">
         <f:textbox/>
-    </f:entry>    
-    <f:entry title="${%PRQA·Framework Installation path}" field="qafHome">
+    </f:entry>
+    <f:entry title="${%PRQA·Framework Installation path}"
+             field="qafHome">
         <f:textbox/>
     </f:entry>
     <tr>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/threshold/FileComplianceThreshold/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/threshold/FileComplianceThreshold/config.jelly
@@ -1,10 +1,13 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:entry title="${%File compliance target}" field="value">
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
+    <f:entry title="${%File compliance target}"
+             field="value">
         <f:textbox/>
     </f:entry>
-    
-    <f:entry title="${%Continuous improvement}" field="improvement" >
+
+    <f:entry title="${%Continuous improvement}"
+             field="improvement">
         <f:checkbox/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/threshold/MessageComplianceThreshold/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/threshold/MessageComplianceThreshold/config.jelly
@@ -1,10 +1,13 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:entry title="${%Max messages target}" field="value" >
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
+    <f:entry title="${%Max messages target}"
+             field="value">
         <f:textbox/>
     </f:entry>
-    <f:entry title="${%Continuous improvement}" field="improvement" >
+    <f:entry title="${%Continuous improvement}"
+             field="improvement">
         <f:checkbox/>
     </f:entry>
-    
+
 </j:jelly>

--- a/src/main/resources/net/praqma/jenkins/plugin/prqa/threshold/ProjectComplianceThreshold/config.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/prqa/threshold/ProjectComplianceThreshold/config.jelly
@@ -1,12 +1,15 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    
-    <f:entry title="${%Project compliance target}" field="value" >
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
+
+    <f:entry title="${%Project compliance target}"
+             field="value">
         <f:textbox/>
     </f:entry>
-    
-    <f:entry title="${%Continuous improvement}" field="improvement" >
+
+    <f:entry title="${%Continuous improvement}"
+             field="improvement">
         <f:checkbox/>
     </f:entry>
-    
+
 </j:jelly>


### PR DESCRIPTION
Defined baseline Jenkins 2.0
Forced commons-lang 2.6 for comatibility
Added escaping to all *.jelly
Optimized imports in all *.jelly
Fixed compatibility issues in certain jelly tags
Updated Jenkins Callables to MasterToSlaveCallables for better compatibility
Fixed all issues found by findbugs
Reviewed all deprecated usages
Improved artifact archiving